### PR TITLE
appliance_finishing_power_threshold min 1.0 -> 0.1

### DIFF
--- a/appliance-status-monitor.yaml
+++ b/appliance-status-monitor.yaml
@@ -85,7 +85,7 @@ blueprint:
       default: 3
       selector:
         number:
-          min: 1.0
+          min: 0.1
           max: 100.0
           unit_of_measurement: W
           mode: slider


### PR DESCRIPTION
This PR allows setting appliance_finishing_power_threshold lower than 1.
It is useful in case when, for example, the dishwasher consumes 0.6 Watts while waiting for program to finish and consumes 0.4 Watts when idle.
<img width="547" alt="Screenshot 2022-08-13 at 02 08 48" src="https://user-images.githubusercontent.com/64733669/184455459-d40d2bbd-6089-439b-b236-088e052b6c93.png">

