### PR TITLE
Filter automation entity by power device_class

### DIFF
--- a/appliance-status-monitor.yaml
+++ b/appliance-status-monitor.yaml
@@ -58,6 +58,8 @@ blueprint:
       selector:
         entity:
           domain: sensor
+          device_class: power
+          multiple: false
     appliance_starting_power_threshold:
       name: Starting power threshold
       description: >-


### PR DESCRIPTION
I recently ran into some issues because I'd accidentally selected a sensor for current, voltage, or energy instead of power

This change filters the entities in the UI to make sure you're selecting a power sensor!